### PR TITLE
[2021-01-18]용석:사용자 계정 생성 API 및 TC 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,32 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <!--
+            - maven Central URL : https://mvnrepository.com/artifact/org.modelmapper/modelmapper
+            - [용석:2020-08-17] : 입력값에 의해 결정되거나, 시스템이 자동으로 값을 할당하는 항목의 입력값을 제한하기 위해 분리한
+                                  요청 객체와 Entity객체의 Mapping을 위한 modelmapper dependency 추가
+        -->
+        <dependency>
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper</artifactId>
+            <version>2.3.9</version>
+        </dependency>
 
         <!-- About Authentication -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <!-- About Validation -->
+        <!--
+            - Maven Central URL : https://mvnrepository.com/artifact/jakarta.validation/jakarta.validation-api
+            - [용석:2020-08-21] : Java Bean객체의 기본 유효성 검사를 위한 spring-boot-starter-validation 추가
+            - 참고 URL : https://meetup.toast.com/posts/223
+        -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         
         <!-- About Test -->

--- a/src/main/java/io/example/authorization/config/ApplicationConfig.java
+++ b/src/main/java/io/example/authorization/config/ApplicationConfig.java
@@ -1,5 +1,6 @@
 package io.example.authorization.config;
 
+import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
@@ -14,5 +15,10 @@ public class ApplicationConfig {
     @Bean
     public PasswordEncoder passwordEncoder(){
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
+    public ModelMapper modelMapper(){
+        return new ModelMapper();
     }
 }

--- a/src/main/java/io/example/authorization/config/CustomMediaTypeConstants.java
+++ b/src/main/java/io/example/authorization/config/CustomMediaTypeConstants.java
@@ -1,0 +1,5 @@
+package io.example.authorization.config;
+
+public interface CustomMediaTypeConstants {
+    String HAL_JSON_UTF8_VALUE = "application/hal+json;charset=UTF-8";
+}

--- a/src/main/java/io/example/authorization/config/SecurityConfig.java
+++ b/src/main/java/io/example/authorization/config/SecurityConfig.java
@@ -1,0 +1,16 @@
+package io.example.authorization.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable();
+    }
+}

--- a/src/main/java/io/example/authorization/controller/PartnerAccountController.java
+++ b/src/main/java/io/example/authorization/controller/PartnerAccountController.java
@@ -1,0 +1,73 @@
+package io.example.authorization.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.example.authorization.domain.common.ProcessingResult;
+import io.example.authorization.domain.common.resource.ErrorsEntityModel;
+import io.example.authorization.domain.common.resource.ProcessingResultEntityModel;
+import io.example.authorization.domain.partner.dto.PartnerSignUp;
+import io.example.authorization.domain.partner.entity.PartnerAccountEntity;
+import io.example.authorization.service.PartnerAccountService;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+@RestController
+@RequestMapping(value = "/api/partner")
+@RequiredArgsConstructor
+public class PartnerAccountController {
+
+    private final ModelMapper modelMapper;
+    private final PartnerAccountService partnerAccountService;
+
+    @PostMapping
+    public ResponseEntity createPartnerAccount(@RequestBody @Valid PartnerSignUp partnerSignUp, Errors errors) throws JsonProcessingException {
+        if(errors.hasErrors()){
+            return this.badRequest(errors);
+        }
+
+        PartnerAccountEntity partnerAccountEntity = this.modelMapper.map(partnerSignUp, PartnerAccountEntity.class);
+        ProcessingResult processingResult = this.partnerAccountService.savePartnerAccount(partnerAccountEntity);
+
+        if(processingResult.isSuccess()){
+            return this.createResponse(processingResult);
+        }else{
+            return this.errorResponse(processingResult);
+        }
+    }
+
+    /**
+     * Service 처리 결과가 성공이 아닌경우 오류 응답 처리
+     */
+    private ResponseEntity errorResponse(ProcessingResult processingResult) {
+        int errorCode = processingResult.getError().getCode();
+        switch (errorCode){
+            case 500:
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(processingResult.getError());
+            default:
+                return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(processingResult.getError());
+        }
+    }
+
+    /**
+     * POST 요청의 created 응답 처리
+     */
+    private ResponseEntity<ProcessingResultEntityModel> createResponse(ProcessingResult processingResult) {
+        URI location = linkTo(PartnerAccountController.class).withSelfRel().toUri();
+        return ResponseEntity.created(location).body(new ProcessingResultEntityModel(processingResult));
+    }
+
+    public ResponseEntity badRequest(Errors errors){
+        return ResponseEntity.badRequest().body(new ErrorsEntityModel(errors));
+    }
+}

--- a/src/main/java/io/example/authorization/domain/common/resource/ErrorsEntityModel.java
+++ b/src/main/java/io/example/authorization/domain/common/resource/ErrorsEntityModel.java
@@ -1,0 +1,17 @@
+package io.example.authorization.domain.common.resource;
+
+import io.example.authorization.controller.IndexController;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+import org.springframework.validation.Errors;
+
+import static org.springframework.hateoas.IanaLinkRelations.INDEX;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+public class ErrorsEntityModel extends EntityModel<Errors> {
+
+    public ErrorsEntityModel(Errors content, Link... links) {
+        super(content, links);
+        add(linkTo(IndexController.class).withRel(INDEX));
+    }
+}

--- a/src/main/java/io/example/authorization/domain/common/resource/ProcessingResultEntityModel.java
+++ b/src/main/java/io/example/authorization/domain/common/resource/ProcessingResultEntityModel.java
@@ -1,0 +1,17 @@
+package io.example.authorization.domain.common.resource;
+
+import io.example.authorization.controller.IndexController;
+import io.example.authorization.domain.common.ProcessingResult;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+
+import static org.springframework.hateoas.IanaLinkRelations.INDEX;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+public class ProcessingResultEntityModel extends EntityModel<ProcessingResult> {
+
+    public ProcessingResultEntityModel(ProcessingResult processingResult, Link... links) {
+        super(processingResult, links);
+        add(linkTo(IndexController.class).withRel(INDEX));
+    }
+}

--- a/src/main/java/io/example/authorization/domain/partner/dto/PartnerSignUp.java
+++ b/src/main/java/io/example/authorization/domain/partner/dto/PartnerSignUp.java
@@ -1,0 +1,29 @@
+package io.example.authorization.domain.partner.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@ToString
+@Builder @NoArgsConstructor @AllArgsConstructor
+public class PartnerSignUp {
+
+    @NotBlank(message = "아이디를 입력하세요.")
+    @Size(min = 3, max = 10, message = "아이디는 3~15자 이내로 입력 가능합니다.")
+    private String partnerId;
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Size(min = 6, max = 25, message = "비밀번호는 6~25자 이내로 입력 가능합니다.")
+    private String partnerPassword;
+
+    @Email(message = "이메일 양식에 맞게 입력하세요")
+    @NotBlank(message = "메일주소를 입력하세요.")
+    private String partnerEmail;
+
+    @NotBlank(message = "회사명을 입력하세요.")
+    private String partnerCompanyName;
+}

--- a/src/main/java/io/example/authorization/util/serializer/ErrorsSerializer.java
+++ b/src/main/java/io/example/authorization/util/serializer/ErrorsSerializer.java
@@ -1,0 +1,60 @@
+package io.example.authorization.util.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.springframework.boot.jackson.JsonComponent;
+import org.springframework.validation.Errors;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@JsonComponent
+public class ErrorsSerializer extends JsonSerializer<Errors> {
+    private final String OBJECT_NAME = "objectName";
+    private final String FIELD = "field";
+    private final String CODE = "code";
+    private final String DEFAULT_MESSAGE = "defaultMessage";
+    private final String REJECTED_VALUE = "rejectedValue";
+    private final String ARGUMENT = "argument";
+
+    @Override
+    public void serialize(Errors errors, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeFieldName("errors");
+        jsonGenerator.writeStartArray();
+        errors.getFieldErrors().stream().forEach(error -> {
+            try {
+                jsonGenerator.writeStartObject();
+                jsonGenerator.writeStringField(OBJECT_NAME, error.getObjectName());
+                jsonGenerator.writeStringField(FIELD, error.getField());
+                jsonGenerator.writeStringField(CODE, error.getCode());
+                jsonGenerator.writeStringField(DEFAULT_MESSAGE, error.getDefaultMessage());
+                Object rejectedValue = error.getRejectedValue();
+                if(rejectedValue != null) {
+                    jsonGenerator.writeStringField(REJECTED_VALUE, rejectedValue.toString());
+                }
+                jsonGenerator.writeEndObject();
+            } catch (IOException ioException) {
+                ioException.printStackTrace();
+            }
+        });
+
+        errors.getGlobalErrors().stream().forEach(error -> {
+            try {
+                jsonGenerator.writeStartObject();
+                jsonGenerator.writeStringField(OBJECT_NAME, error.getObjectName());
+                jsonGenerator.writeStringField(CODE, error.getCode());
+                jsonGenerator.writeStringField(DEFAULT_MESSAGE, error.getDefaultMessage());
+
+                Object[] arguments = error.getArguments();
+                if(arguments != null){
+                    jsonGenerator.writeStringField(ARGUMENT, Arrays.toString(error.getArguments()));
+                }
+                jsonGenerator.writeEndObject();
+            } catch (IOException ioException) {
+                ioException.printStackTrace();
+            }
+        });
+        jsonGenerator.writeEndArray();
+    }
+}

--- a/src/test/java/io/example/authorization/controller/PartnerAccountControllerFailTest.java
+++ b/src/test/java/io/example/authorization/controller/PartnerAccountControllerFailTest.java
@@ -1,0 +1,47 @@
+package io.example.authorization.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.example.authorization.config.CustomMediaTypeConstants;
+import io.example.authorization.domain.partner.dto.PartnerSignUp;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@AutoConfigureMockMvc
+class PartnerAccountControllerFailTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("사용자 계정 생성 API : 값이 없는 사용자 계정 생성 요청")
+    public void createPartnerAPI_EmptyRequest() throws Exception {
+        //given
+        PartnerSignUp partnerSignUp = PartnerSignUp.builder()
+                .build();
+
+        //when
+        ResultActions resultActions = this.mockMvc.perform(post("/api/partner")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(CustomMediaTypeConstants.HAL_JSON_UTF8_VALUE)
+                .content(this.objectMapper.writeValueAsString(partnerSignUp))
+        );
+
+        //then
+        resultActions.andDo(print());
+    }
+}

--- a/src/test/java/io/example/authorization/controller/PartnerAccountControllerSuccessTest.java
+++ b/src/test/java/io/example/authorization/controller/PartnerAccountControllerSuccessTest.java
@@ -1,0 +1,61 @@
+package io.example.authorization.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.example.authorization.config.CustomMediaTypeConstants;
+import io.example.authorization.domain.partner.dto.PartnerSignUp;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@AutoConfigureMockMvc
+class PartnerAccountControllerSuccessTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("사용자 계정 생성 API")
+    public void createPartnerAccount() throws Exception {
+        //given
+        String partnerId = "choi-ys";
+        String partnerPassword = "password";
+        String partnerEmail = "project.log.062@gmail.com";
+        String partnerCompanyName = "naver";
+
+        PartnerSignUp partnerSignUp = PartnerSignUp.builder()
+                .partnerId(partnerId)
+                .partnerPassword(partnerPassword)
+                .partnerEmail(partnerEmail)
+                .partnerCompanyName(partnerCompanyName)
+                .build();
+
+        //when
+        ResultActions resultActions = this.mockMvc.perform(post("/api/partner")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(CustomMediaTypeConstants.HAL_JSON_UTF8_VALUE)
+                .content(this.objectMapper.writeValueAsString(partnerSignUp))
+        );
+
+        resultActions.andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(header().exists(HttpHeaders.LOCATION))
+                .andExpect(header().exists(HttpHeaders.CONTENT_TYPE))
+                .andExpect(jsonPath("_links").exists())
+        ;
+    }
+}

--- a/src/test/java/io/example/authorization/domain/partner/entity/PartnerAccountEntityTest.java
+++ b/src/test/java/io/example/authorization/domain/partner/entity/PartnerAccountEntityTest.java
@@ -1,0 +1,37 @@
+package io.example.authorization.domain.partner.entity;
+
+import io.example.authorization.domain.partner.dto.PartnerSignUp;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PartnerAccountEntityTest {
+
+    @Test
+    public void modelMapperTest(){
+        //given
+        String partnerId = "choi-ys";
+        String partnerPassword = "password";
+        String partnerEmail = "project.log.062@gmail.com";
+        String partnerCompanyName = "";
+
+        PartnerSignUp partnerSignUp = PartnerSignUp.builder()
+                .partnerId(partnerId)
+                .partnerPassword(partnerPassword)
+                .partnerEmail(partnerEmail)
+                .partnerCompanyName(partnerCompanyName)
+                .build();
+
+        ModelMapper modelMapper = new ModelMapper();
+
+        //when
+        PartnerAccountEntity partnerAccountEntity = modelMapper.map(partnerSignUp, PartnerAccountEntity.class);
+
+        //then
+        assertThat(partnerAccountEntity.getPartnerId()).isEqualTo(partnerId);
+        assertThat(partnerAccountEntity.getPartnerPassword()).isEqualTo(partnerPassword);
+        assertThat(partnerAccountEntity.getPartnerEmail()).isEqualTo(partnerEmail);
+        assertThat(partnerAccountEntity.getPartnerCompanyName()).isEqualTo(partnerCompanyName);
+    }
+}


### PR DESCRIPTION
 - API 응답 Content-Type 정의 : application/hal+json;charset=UTF-8
 - API 요청 파라미터 유효성 검사
  - 입력을 제한하기 위한 요청 객체 정의
  - Java Bean객체의 기본 유효성 검사를 위한 spring-boot-starter-validation 의존성 추가
  - Controller 요청 수신 부에 @Valid Annotation을 이용한 객체 Binding시 유효성 검사 적용
 - 유효성 검사에서 발생한 Errors객체의 응답 처리
     - Errors객체 직렬화를 위한 Serializer 구현
     - Resource형태의 응답 처리를 위한 ErrorsEntityModel 구현
     - ErrorsEntityModel을 이용한 Errors 객체 응답 반환 처리
 - 분리한 입력객체와 Entity객체를 Mapping하기 위한 modelMapper 의존성 추가
 - POST요청 허용을 위한 SpringSecurity 임시 설정
 - 사용자 계정 Service 호출 및 로직 처리 결과 응답 처리
   - Resource형태의 응답 처리를 위한 ProcessingResultEntityModel 구현