### PR TITLE
[2021-01-18]용석:InMemory 환경에서 Authorization Code 방식의 인증 토큰 발급

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <!--
+            - Maven Central URL : https://mvnrepository.com/artifact/org.springframework.security.oauth.boot/spring-security-oauth2-autoconfigure
+            - [용석:2020-09-16] : Oauth방식을 이용하여 권한/인가 처리를 위한 spring-security-oauth2-autoconfigure 추가
+        -->
+        <dependency>
+            <groupId>org.springframework.security.oauth.boot</groupId>
+            <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+            <version>2.1.0.RELEASE</version>
+        </dependency>
 
         <!-- About Validation -->
         <!--

--- a/src/main/java/io/example/authorization/config/ApplicationConfig.java
+++ b/src/main/java/io/example/authorization/config/ApplicationConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.client.RestTemplate;
 
 /** 용석 : 2021-01-18
  * Application 전체에서 사용하는 Bean설정
@@ -20,5 +21,10 @@ public class ApplicationConfig {
     @Bean
     public ModelMapper modelMapper(){
         return new ModelMapper();
+    }
+
+    @Bean
+    public RestTemplate restTemplate(){
+        return new RestTemplate();
     }
 }

--- a/src/main/java/io/example/authorization/config/AuthorizationConfig.java
+++ b/src/main/java/io/example/authorization/config/AuthorizationConfig.java
@@ -1,0 +1,24 @@
+package io.example.authorization.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+
+@Configuration
+@EnableAuthorizationServer
+public class AuthorizationConfig extends AuthorizationServerConfigurerAdapter {
+
+    // http://localhost:8080/oauth/authorize?client_id=clientId&response_type=code&scope=read&redirect_uri=http://localhost:8080/oauth/callback
+    @Override
+    public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
+        clients.inMemory()
+                .withClient("clientId")
+                .secret("{noop}clientSecret")
+                .authorizedGrantTypes("authorization_code", "refresh_token")
+                .redirectUris("http://localhost:8080/oauth/callback")
+                .scopes("read", "write")
+                .accessTokenValiditySeconds(60 * 10)
+        ;
+    }
+}

--- a/src/main/java/io/example/authorization/config/SecurityConfig.java
+++ b/src/main/java/io/example/authorization/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package io.example.authorization.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -11,6 +12,22 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable();
+        http
+                .csrf().disable()
+                .headers().frameOptions().disable()
+                .and()
+                .authorizeRequests().antMatchers("/oauth/**", "/oauth/callback", "/h2-console/*").permitAll()
+                .and()
+                .formLogin().and()
+                .httpBasic();
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.inMemoryAuthentication()
+                .withUser("choi-ys")
+                .password("{noop}password")
+                .roles("USER")
+        ;
     }
 }

--- a/src/main/java/io/example/authorization/controller/TokenReceptionController.java
+++ b/src/main/java/io/example/authorization/controller/TokenReceptionController.java
@@ -1,0 +1,50 @@
+package io.example.authorization.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.example.authorization.domain.authorization.AuthToken;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.http.*;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/oauth")
+@Slf4j
+public class TokenReceptionController {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @GetMapping(value = "/callback")
+    public AuthToken callbackSocial(@RequestParam String code) throws JsonProcessingException {
+        String credentials = "clientId:clientSecret";
+        String encodedCredentials = new String(Base64.encodeBase64(credentials.getBytes()));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.add("Authorization", "Basic " + encodedCredentials);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("grant_type", "authorization_code");
+        params.add("redirect_uri", "http://localhost:8080/oauth/callback");
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        ResponseEntity<String> response = restTemplate.postForEntity("http://localhost:8080/oauth/token", request, String.class);
+        if (response.getStatusCode() == HttpStatus.OK) {
+            AuthToken authToken = this.objectMapper.readValue(response.getBody(), AuthToken.class);
+            log.info(this.objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(authToken));
+            return authToken;
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/example/authorization/domain/authorization/AuthToken.java
+++ b/src/main/java/io/example/authorization/domain/authorization/AuthToken.java
@@ -1,0 +1,14 @@
+package io.example.authorization.domain.authorization;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AuthToken {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private long expires_in;
+    private String scope;
+}


### PR DESCRIPTION
 - pom.xml : OAuth2 방식의 API 권한/인가 Token발급을 위한 spring-security-oauth2-autoconfigure 의존성 추가
 - AuthorizationConfig.java : 인증된 사용자와 명시된 Client 정보를 이용한 authorization code방식의 Token 발급 설정 추가
 - SecurityConfig.java : InMemory환경에 인증이 허용된 사용자 정보 설정
 - Authorization Code 방식의 토큰 발급 Test를 위한 Client 토큰발급 요청/수신 부 구현
   - ApplicationConfig.java : 인증 서버와 통신을 위한 RestTemplate 등록
   - AuthToken.java : 발급받은 Token 데이터 수신을 위한 객체 구현
   - TokenReceptionController : 인증서버에 Authorization Code 요청 및 Token 발급 요청 부