### PR TITLE
[2021-01-19]용석:토큰 발급/갱신 요청 시 DB의 사용자 정보를 참조하여 인증 토큰 발급

### DIFF
--- a/src/main/java/io/example/authorization/config/AuthorizationConfig.java
+++ b/src/main/java/io/example/authorization/config/AuthorizationConfig.java
@@ -1,11 +1,14 @@
 package io.example.authorization.config;
 
+import io.example.authorization.service.PartnerService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
 
 import javax.sql.DataSource;
 
@@ -21,7 +24,6 @@ public class AuthorizationConfig extends AuthorizationServerConfigurerAdapter {
 
     // http://localhost:8080/oauth/authorize?client_id=clientId&response_type=code&scope=read&redirect_uri=http://localhost:8080/oauth/callback
     // http://localhost:8080/oauth/authorize?client_id=kstmClientId&response_type=code&scope=read&redirect_uri=http://localhost:8080/oauth/callback
-
     @Override
     public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
         /**
@@ -49,5 +51,18 @@ public class AuthorizationConfig extends AuthorizationServerConfigurerAdapter {
          *              client_id = ?";
          */
         clients.jdbc(dataSource).passwordEncoder(passwordEncoder);
+    }
+
+    @Autowired
+    AuthenticationManager authenticationManager;
+
+    @Autowired
+    PartnerService partnerService;
+
+    @Override
+    public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
+        endpoints.authenticationManager(authenticationManager) // Account 인증 정보를 소유한 Bean
+                .userDetailsService(partnerService) // Account 인증 처리 Service Bean
+        ;
     }
 }

--- a/src/main/java/io/example/authorization/config/SecurityConfig.java
+++ b/src/main/java/io/example/authorization/config/SecurityConfig.java
@@ -1,10 +1,15 @@
 package io.example.authorization.config;
 
+import io.example.authorization.service.PartnerService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
@@ -22,12 +27,22 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .httpBasic();
     }
 
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private PartnerService partnerService;
+
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.inMemoryAuthentication()
-                .withUser("choi-ys")
-                .password("{noop}password")
-                .roles("USER")
+        auth.userDetailsService(partnerService)     // 사용자 정보 조회 부 등록
+                .passwordEncoder(passwordEncoder)   // 사용자 정보의 암호화 여부를 확인할 encoder 등록
         ;
     }
 }

--- a/src/main/java/io/example/authorization/repository/PartnerRepository.java
+++ b/src/main/java/io/example/authorization/repository/PartnerRepository.java
@@ -3,6 +3,9 @@ package io.example.authorization.repository;
 import io.example.authorization.domain.partner.entity.PartnerEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PartnerRepository extends JpaRepository<PartnerEntity, Long> {
     long countByPartnerId(String id);
+    Optional<PartnerEntity> findByPartnerId(String partnerId);
 }

--- a/src/main/java/io/example/authorization/service/PartnerService.java
+++ b/src/main/java/io/example/authorization/service/PartnerService.java
@@ -3,14 +3,25 @@ package io.example.authorization.service;
 import io.example.authorization.domain.common.Error;
 import io.example.authorization.domain.common.ProcessingResult;
 import io.example.authorization.domain.partner.entity.PartnerEntity;
+import io.example.authorization.domain.partner.entity.PartnerRole;
 import io.example.authorization.repository.PartnerRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
-public class PartnerService {
+public class PartnerService implements UserDetailsService {
 
     private final PartnerRepository partnerRepository;
     private final PasswordEncoder passwordEncoder;
@@ -57,5 +68,43 @@ public class PartnerService {
                 .detail(e.getMessage())
                 .build()
         );
+    }
+
+    /**
+     * Application에서 정의한 Account domain을 Spring security에서 정의한 UsertDetail Interface로 변환
+     * @param partnerId
+     * @return
+     * @throws UsernameNotFoundException
+     */
+    @Override
+    public UserDetails loadUserByUsername(String partnerId) throws UsernameNotFoundException {
+        PartnerEntity partnerAccountEntity = partnerRepository.findByPartnerId(partnerId)
+                /**
+                 * 요청 파라미터에 해당하는 Account 객체 조회 실패 시 오류 반환 처리
+                 * - userName(account.email)에 해당 하는 Account 객체 조회 실패 시 Null을 반환 하므로
+                 * - Srping security의 UsernameNotFoundException객체를 통해 정의된 오류를 반환한다.
+                 */
+                .orElseThrow(() -> new UsernameNotFoundException(partnerId));
+
+        /**
+         * Srping security의 User객체를 이용하여 MemberEntity객체를 UserDetails 객체로 변환
+         *  - UserDetails interface로 객체 변환 처리를 구현할 경우 모든 메소드를 구현 해야하므로,
+         *  - UserDetails의 User객체를 이용하여 MemberEntity 체를 Spring Security의 UserDetails 객체로 변환한다.
+         */
+        return new User(partnerAccountEntity.getPartnerId(),
+                partnerAccountEntity.getPartnerPassword(),
+                this.roleToAuthorities(partnerAccountEntity.getRoles())
+        );
+    }
+
+    /**
+     * Set으로 정의된 Role을 Collection Type으로 변환
+     * @param roles
+     * @return
+     */
+    private Collection<? extends GrantedAuthority> roleToAuthorities(Set<PartnerRole> roles) {
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.name()))
+                .collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
 - Spring Security를 적용한 Application에서 사용자 정보 조회 시 사용하는 UserDetailsService의 loadUserByUsername 구현
 - UserDetailsService의 loadUserByUsername을 통해 조회한 사용자 정보를 Application 전역에서 참조할 수 있도록 AuthenticationManager에 조회한 사용자 정보 등록
 - 토큰 발급/갱신 요청 시 요청 사용자 정보 및 인증 여부를 참조 시 DB에서 조회하여 AuthenticationManager에 등록한 사용자 정보 참조